### PR TITLE
Thymeleafを使って受講生情報と受講生コース情報の画面描画を実装

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -1,0 +1,46 @@
+package raisetech.student.management.controller;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+import raisetech.student.management.model.domain.StudentDetail;
+import raisetech.student.management.model.services.StudentService;
+
+@Controller
+public class StudentController {
+
+  private final StudentService service;
+  private final StudentConverter converter;
+  private static final Logger logger = LoggerFactory.getLogger(StudentController.class);
+
+  public StudentController(StudentService service, StudentConverter converter) {
+    this.service = service;
+    this.converter = converter;
+  }
+
+  @GetMapping("/studentList")
+  public String getStudentList(Model model) {
+    List<Student> students = service.searchStudentList();
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+    List<StudentDetail> studentsDetails = converter.convertStudentDetails(students,
+        studentsCourses);
+
+    // ビュー（studentListテンプレート）の${studentList}にstudentsDetailsを渡す。
+    model.addAttribute("studentList", studentsDetails);
+    return "studentList"; // studentList.htmlを指す。
+  }
+
+  @GetMapping("/studentCourseList")
+  public String getStudentCourseList(Model model) {
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+
+    model.addAttribute("studentCourseList", studentsCourses);
+    return "studentCourseList"; // studentCourseList.htmlを指す。
+  }
+}

--- a/src/main/resources/templates/studentCourseList.html
+++ b/src/main/resources/templates/studentCourseList.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生コース情報一覧</title>
+</head>
+<body>
+<h1>受講生コース一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>生徒ID</th>
+    <th>コース名</th>
+    <th>開始日時</th>
+    <th>修了予定日時</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentCourse : ${studentCourseList}">
+    <td th:text="${studentCourse.id}">1</td>
+    <td th:text="${studentCourse.studentId}">2</td>
+    <td th:text="${studentCourse.courseName}">Java</td>
+    <td th:text="${studentCourse.startDate}">2024年4月1日</td>
+    <td th:text="${studentCourse.endDate}">2025年4月1日</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<!--名前空間の宣言。thを持つ属性をThymeleafの属性として認識させることができる-->
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生情報一覧</title>
+</head>
+<body>
+<h1>受講生一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>住所</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>受講コース</th>
+    <th>備考</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${studentList}">
+    <!--  以下、タグ内のデフォルト値（山田太郎など）はプレースホルダ{fullnameなど}によって置き換えられる-->
+    <td th:text="${studentDetail.student.id}">1</td>
+    <td th:text="${studentDetail.student.fullname}">山田太郎</td>
+    <td th:text="${studentDetail.student.furigana}">やまだたろう</td>
+    <td th:text="${studentDetail.student.nickname}">やまちゃん</td>
+    <td th:text="${studentDetail.student.mail}">mailadress@example.com</td>
+    <td th:text="${studentDetail.student.address}">東京</td>
+    <td th:text="${studentDetail.student.age}">26</td>
+    <td th:text="${studentDetail.student.gender}">男性</td>
+    <td>
+      <span th:each="course, iterStat : ${studentDetail.studentCourse}">
+        <span th:text="${course.courseName}"></span>
+        <span th:if="${!iterStat.last}">,</span>
+      </span>
+    </td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
**新カリキュラム第27回の課題（Thymeleafを使ったReadの画面描画処理）を以下のとおり実施いたしましたので、ご確認をお願いいたします。**
***
## 概要
**◆Thymeleafを使って、受講生一覧および受講生コース一覧を画面描画するアプリを作成しました。**

**◆MySQLで用意したデータテーブルは、以下の通りです**
1. students
![受講生](https://github.com/YaraiM/JavaNewChapter27Assignment/assets/153747182/c218a097-df04-4028-93b8-c56516ba0edc)


2. students_courses
　<img src="https://github.com/YaraiM/JavaNewChapter27Assignment/assets/153747182/a432bdd8-7317-4dfd-be57-143d6f976801" width="70%">

***
 
## 動作確認
**◆パスとして/studentListを指定すると、ブラウザに以下のような受講生情報一覧が表示されます。**

![受講生一覧の画面描画](https://github.com/YaraiM/JavaNewChapter27Assignment/assets/153747182/547809e3-c73b-4c45-835e-0916e7ab3bd5)


**◆パスとして/studentCourseListを指定すると、ブラウザに以下のような受講生コース一覧が表示されます。**

  <img src="https://github.com/YaraiM/JavaNewChapter27Assignment/assets/153747182/96511d18-8d23-4597-a5f4-89950630361a" width="50%">
